### PR TITLE
Generate the slide deck in GitHub CDN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+
+
+gh-pages:
+	@echo "Clearing out old gh-pages branch if it exists"
+	-git branch -D gh-pages
+	-git push origin --delete gh-pages
+	@echo "Creating fresh gh-pages branch"
+	git checkout --orphan gh-pages
+	@echo "Adding all docs to this branch"
+	find . -type f -not -path "./.git*" \( -name "*" -a -type f \) | xargs git add -f 
+	@echo "Manual intervention time....  Check if things look good then follow directions"
+	git add -f
+	git status
+
+
+gh-pages-push:	
+	git commit -m'Adding gh-pages pushes'
+	git push origin gh-pages
+	git checkout master
+

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Repo Contents
 - [implementation](implementation/): Example implementation using Connexions.
 - [presentation](presentation/): HTML presentation and source.
 - [work](work/): Working directory for your lessons.
+
+Slides
+------
+https://gwood.github.io/OpenAPI-Tutorial/presentation/presentation.html#1
+
+Building the Slides in Your Repo
+--------------------------------
+$ make gh-pages
+$ make gh-pages-push


### PR DESCRIPTION
We can use a small Makefile, credit to my colleague Michael Hale for this trick, to create and push a set of pages to the GitHub gh-pages site.
Then the slides are viewable.

To demo the slides I have used my own repo as a demonstration of the technique.
Fix that by changing to the original repo location in the URL once the build has been completed.

George Wood